### PR TITLE
Some item-finding fixes

### DIFF
--- a/osrs/finders/items/itemfinder.simba
+++ b/osrs/finders/items/itemfinder.simba
@@ -23,30 +23,31 @@ type
 
 function TRSItemFinder.Align(image, template: TImage): Boolean;
 var
-  borderA, borderB: TPointArray;
+  borderA, borderB, tmp1, tmp2: TPointArray;
   bounds: TBox;
   align, p: TPoint;
 begin
-  borderA  := image.FindColor(RSColors.ITEM_BORDER, 0);
-  borderB := template.FindColor(RSColors.ITEM_BORDER, 0) + template.FindColor(RSColors.ITEM_BORDER_WHITE, 0);
+  borderA := image.FindColor(RSColors.ITEM_BORDER, 0);
+  tmp1    := borderA.ExcludeBox([0,0,image.Width,8]);
+  borderA := tmp1;
+  borderB := template.FindColor($000000, 1) + template.FindColor(RSColors.ITEM_BORDER_WHITE, 0);
+  tmp2    := borderB.ExcludeBox([0,0,template.Width,8]);
+  borderB := tmp2;
 
-  if (borderA.Length = 0) or (borderB.Length = 0) then
-  begin
-    Exit;
-  end;
+  if (borderA.Length = 0) or (borderB.Length = 0) then Exit;
+
   align := borderA[High(borderA)] - borderB[High(borderB)];
-
   borderB := borderB.Offset(align);
+
   for p in borderB do
   begin
     if p.Y <= 8 then Continue;//stack number... Don't compare.
 
-    //borders don't match.
     if not image.InImage(p.X, p.Y) then Exit;
-    if image.Pixel[p.X, p.Y] <> RSColors.ITEM_BORDER then Exit;
+    if (image.Pixel[p.X, p.Y] <> RSColors.ITEM_BORDER) then Exit;
   end;
 
-  bounds := borderA.Bounds();
+  bounds := borderA.Bounds;
   image.Crop(bounds);
   template.Crop(bounds.Offset([-align.X, -align.Y]));
   Result := True;

--- a/osrs/interfaces/gametabs/inventory.simba
+++ b/osrs/interfaces/gametabs/inventory.simba
@@ -8,6 +8,26 @@ Methods to interact with the inventory gametab.
 {$DEFINE WL_INVENTORY_INCLUDED}
 {$INCLUDE_ONCE WaspLib/osrs.simba}
 
+const
+  //Column wise and "reversed" column wise - normal pattern
+  DROP_PATTERN_REGULAR  : TIntegerArray = [0..27];
+  DROP_PATTERN_REGULAR_R: TIntegerArray = [3,2,1,0, 7,6,5,4, 11,10,9,8, 15,14,13,12, 19,18,17,16, 23,22,21,20, 27,26,25,24];
+
+  //Column wise snake and "reversed" version
+  DROP_PATTERN_SNAKE    : TIntegerArray = [0,1,2,3, 7,6,5,4, 8,9,10,11, 15,14,13,12, 16,17,18,19, 23,22,21,20, 24,25,26,27];
+  DROP_PATTERN_SNAKE_R  : TIntegerArray = [3,2,1,0, 4,5,6,7, 11,10,9,8, 12,13,14,15, 19,18,17,16, 20,21,22,23, 27,26,25,24];
+
+  //by row (and "reversed")
+  DROP_PATTERN_TOPDOWN  : TIntegerArray = [0,4,8,12,16,20,24,  1,5,9,13,17,21,25,  2,6,10,14,18,22,26, 3,7,11,15,19,23,27];
+  DROP_PATTERN_TOPDOWN_R: TIntegerArray = [3,7,11,15,19,23,27, 2,6,10,14,18,22,26, 1,5,9,13,17,21,25,  0,4,8,12,16,20,24];
+
+  //Spiral pattern: Starts in slot 0(top left corner of invy) and circles in a clockwise spiral
+  DROP_PATTERN_SPIRAL   : TIntegerArray = [0,1,2,3, 7,11,15,19,23, 27,26,25,24, 20,16,12,8,4, 5, 6,10,14,18,22, 21,17,13,9];
+
+  //Vertical 2 by 2 columns pattern. Normal and "reversed"
+  DROP_PATTERN_TWO_ROW  : TIntegerArray = [0,4,1,5,2,6,3,7,8,12,9,13,10,14,11,15,16,20,17,21,18,22,19,23,20,24,25,26,27,28];
+  DROP_PATTERN_TWO_ROW_R: TIntegerArray = [0,4,1,5,2,6,3,7,11,15,10,14,9,13,8,12,16,20,17,21,18,22,19,23,20,24,28,27,26,25];
+
 type
 (*
 ## TRSInventory
@@ -343,12 +363,12 @@ begin
 
   if not Self.ShiftEnabled then Exit(Self.Drop(slots));
 
-  boxes := Self.Slots.Boxes();
+  boxes := Self.Slots.Boxes;
   for 1 to attempts do
   begin
     for i := 0 to High(slots) do
     begin
-      if Self.GetSelected() > -1 then
+      if Self.GetSelected > -1 then
       begin
         Self.Select(-1);
         Continue(2);
@@ -357,9 +377,9 @@ begin
       b := boxes[slots[i]];
       if not Self.Slots.IsUsed(b) then Continue;
 
-      if not Keyboard.IsKeyDown(EKeyCode.LSHIFT) then
+      if not Keyboard.IsKeyDown(EKeyCode.SHIFT) then
       begin
-        Keyboard.KeyDown(EKeyCode.LSHIFT);
+        Keyboard.KeyDown(EKeyCode.SHIFT);
         Sleep(95, 170, ERandomDir.LEFT); //Wait for SHIFT to be registered before the click (important).
       end;
 
@@ -368,13 +388,13 @@ begin
       Sleep(0, 250, ERandomDir.LEFT);
     end;
 
-    if Keyboard.IsKeyDown(EKeyCode.LSHIFT) then
-      Keyboard.KeyUp(EKeyCode.LSHIFT);
+    if Keyboard.IsKeyDown(EKeyCode.SHIFT) then
+      Keyboard.KeyUp(EKeyCode.SHIFT);
     Exit(True);
   end;
 
-  if Keyboard.IsKeyDown(EKeyCode.LSHIFT) then
-      Keyboard.KeyUp(EKeyCode.LSHIFT);
+  if Keyboard.IsKeyDown(EKeyCode.SHIFT) then
+      Keyboard.KeyUp(EKeyCode.SHIFT);
 
   WriteLn GetDebugLn('Inventory', 'Shift drop is not enabled, consider enabling it for better performance.' , EErrorLevel.WARN);
   Self.ShiftEnabled := False;

--- a/osrs/interfaces/gametabs/inventory.simba
+++ b/osrs/interfaces/gametabs/inventory.simba
@@ -25,8 +25,8 @@ const
   DROP_PATTERN_SPIRAL   : TIntegerArray = [0,1,2,3, 7,11,15,19,23, 27,26,25,24, 20,16,12,8,4, 5, 6,10,14,18,22, 21,17,13,9];
 
   //Vertical 2 by 2 columns pattern. Normal and "reversed"
-  DROP_PATTERN_TWO_ROW  : TIntegerArray = [0,4,1,5,2,6,3,7,8,12,9,13,10,14,11,15,16,20,17,21,18,22,19,23,20,24,25,26,27,28];
-  DROP_PATTERN_TWO_ROW_R: TIntegerArray = [0,4,1,5,2,6,3,7,11,15,10,14,9,13,8,12,16,20,17,21,18,22,19,23,20,24,28,27,26,25];
+  DROP_PATTERN_TWO_ROW  : TIntegerArray = [0,4,1,5,2,6,3,7,8,12,9,13,10,14,11,15,16,20,17,21,18,22,19,23,20,24,25,26,27];
+  DROP_PATTERN_TWO_ROW_R: TIntegerArray = [0,4,1,5,2,6,3,7,11,15,10,14,9,13,8,12,16,20,17,21,18,22,19,23,20,24,27,26,25];
 
 type
 (*

--- a/osrs/interfaces/mainscreen/bank.simba
+++ b/osrs/interfaces/mainscreen/bank.simba
@@ -138,7 +138,7 @@ var
   b: TBox;
   color: Integer;
 begin
-  final := Target.FindColor(RSColors.ITEM_BORDER, 0, Self.SlotsArea);
+  final := Target.FindColor(RSColors.ITEM_BORDER, 1, Self.SlotsArea);
   if final = [] then Exit;
 
   for color in RSColors.STACK_COLORS do

--- a/osrs/interfaces/xpbar.simba
+++ b/osrs/interfaces/xpbar.simba
@@ -302,18 +302,20 @@ Example:
 WriteLn XPBar.Read();
 ```
 *)
-function TRSXPBar.Read(): UInt64;
+function TRSXPBar.Read: UInt64;
 var
   str: String;
+  count: Integer;
 begin
-  if not Self.Setup() then Exit;
+  if not Self.Setup then Exit;
 
   str := OCR.Recognize(Self.Bounds, Self.Font, [$FFFFFF], 0);
 
   Result := str.ExtractInteger(0);
   if Result = 0 then Exit;
+  count := Target.CountColor($010000, 0, Self.Bounds);
 
-  if Target.CountColor($010000, 0, Self.Bounds) <> 45 then
+  if ((count <> 45) and (not InRange(count, 141, 150))) then
   begin
     WriteLn GetDebugLn('XPBar', 'Your XPBar doesn''t seem to be set to count "Total Experience"', EErrorLevel.WARN);
     WriteLn GetDebugLn('XPBar', 'XP Tracking won''t be used and this can cause issues.', EErrorLevel.WARN);

--- a/utils/item.simba
+++ b/utils/item.simba
@@ -113,10 +113,9 @@ var
   i: Integer;
 begin
   slot := TRSItem.GetStackBox(slot);
-
   for i := 0 to High(RSColors.STACK_COLORS) do
-    if Target.HasColor(RSColors.STACK_COLORS[i], 0, 1, slot) then
-      Exit(OCR.RecognizeNumber(slot, RSFonts.PLAIN_11, [RSColors.STACK_COLORS[i]], 0) * Round(10 ** (3 * i)));
+    if Target.HasColor(RSColors.STACK_COLORS[i], 1, 1, slot) then
+      Exit(OCR.RecognizeNumber(slot, RSFonts.PLAIN_11, [RSColors.STACK_COLORS[i]], 1) * Round(10 ** (3 * i)));
   Result := -1;
 end;
 


### PR DESCRIPTION
-Patches for item-finding (RL & C++client) including the inventory & bank for both singular and stacked items
-Shift-drop now uses the correct key
-Random drop patterns added from previous SRL-T / WL
-XPBar reading now works for both RL and C++