### PR TITLE
fix: JSON freezing

### DIFF
--- a/utils/config.simba
+++ b/utils/config.simba
@@ -22,8 +22,8 @@ Type responsible for dealing with JSON configuration files.
   TConfigJSON = record
     Path: String;
     Data: TJSONItem;
-    Thread: TThread;
     Lock: TLock;
+    ThreadManager: TThreadManager;
   end;
 
 (*
@@ -61,27 +61,49 @@ begin
     Self.Data := NewJSONObject();
 
   Self.Lock := TLock.Create();
-
-  AddOnTerminate(@Self.Lock.Free);
-  AddOnTerminate(@Self.Thread.Free);
-  AddOnTerminate(@Self.Data.Free);
+  Self.ThreadManager.Init(2, EDebugLevel.NONE);
 end;
 
+(*
+## TConfigJSON.Free
+```pascal
+procedure TConfigJSON.Free();
+```
+Properly cleans up all resources used by the TConfigJSON instance.
+Call this when you're done with a config to prevent memory leaks.
+*)
+procedure TConfigJSON.Free();
+begin
+  Self.ThreadManager.Free();
+  if Assigned(Self.Lock) then
+  begin
+    Self.Lock.Free();
+    Self.Lock := nil;
+  end;
+  if Assigned(Self.Data) then
+  begin
+    Self.Data.Free();
+    Self.Data := nil;
+  end;
+end;
 
 procedure TConfigJSON._FileSave();
 var
   path, json: String;
 begin
   Self.Lock.Enter();
-  path := Self.Path;
-  json := Self.Data.ToJSON();
-  Self.Lock.Leave();
+  try
+    if Self.Data = nil then
+      Exit;
 
-  if Self.Data = nil then
-    raise GetDebugLn('TConfigJSON.' + PathExtractNameWithoutExt(path), 'You need to use TConfigJSON.Setup() before trying to save it into a config file.');
+    path := Self.Path;
+    json := Self.Data.ToJSON();
+  finally
+    Self.Lock.Leave();
+  end;
+
   if not FileWrite(path, json) then
     raise GetDebugLn('TConfigJSON.' + PathExtractNameWithoutExt(path), 'Failed to save config.');
-  CurrentThread().Terminate();
 end;
 
 (*
@@ -90,12 +112,14 @@ end;
 procedure TConfigJSON.SaveConfig();
 ```
 Used to save your `TConfigJSON`.
-This spawns a separate thread to deal with the I/O as that's slow.
+This submits the save operation to the thread pool for asynchronous execution.
 *)
 procedure TConfigJSON.SaveConfig();
+var
+  TaskID: String;
 begin
-  Self.Thread.Free();
-  Self.Thread := TThread.Create(@Self._FileSave);
+  TaskID := 'ConfigSave_' + PathExtractNameWithoutExt(Self.Path);
+  Self.ThreadManager.Submit(TaskID, @Self._FileSave);
 end;
 
 

--- a/utils/threading.simba
+++ b/utils/threading.simba
@@ -1,7 +1,7 @@
 (*
 # Threading
 Threading library for managing concurrent and scheduled tasks.
-Includes a thread pool for executing asynchronous operations and a scheduler for 
+Includes a thread pool for executing asynchronous operations and a scheduler for
 recurring tasks with priority queuing and built-in error handling.
 
 Credits: Developed by TazE
@@ -617,16 +617,52 @@ begin
 end;
 
 (*
+## TThreadPool.HasPendingTask
+```pascal
+function TThreadPool.HasPendingTask(const TaskID: String): Boolean;
+```
+Checks if a task with the given ID is already in the queue.
+
+### Parameters
+- `TaskID`: The task identifier to check for.
+
+### Returns
+- `Boolean`: `True` if a task with this ID exists in the queue, `False` otherwise.
+*)
+function TThreadPool.HasPendingTask(const TaskID: String): Boolean;
+var
+  Current: PThreadTask;
+begin
+  Result := False;
+  Self.Queue.Lock.Enter();
+  try
+    Current := Self.Queue.Head;
+    while Current <> nil do
+    begin
+      if Current^.ID = TaskID then
+      begin
+        Result := True;
+        Break;
+      end;
+      Current := Current^.Next;
+    end;
+  finally
+    Self.Queue.Lock.Leave();
+  end;
+end;
+
+(*
 ## TThreadPool.Submit
 ```pascal
-function TThreadPool.Submit(const TaskID: String; Method: procedure() of object; Priority: Integer = 0): Boolean;
+function TThreadPool.Submit(const TaskID: String; Method: procedure() of object; Priority: Integer = 0; AllowDuplicates: Boolean = False): Boolean;
 ```
-Submits a task to the pool's queue for execution. Returns `True` on successful submission.
+Submits a task to the pool's queue for execution. By default, prevents duplicate task IDs. Returns `True` on successful submission.
 
 ### Parameters
 - `TaskID`: A unique identifier for the task.
 - `Method`: The procedure to be executed.
 - `Priority`: The task's priority (higher values execute sooner). Default is 0.
+- `AllowDuplicates`: Whether to allow duplicate task IDs. Default is False.
 
 ### Returns
 - `Boolean`: `True` if task was successfully submitted, `False` otherwise.
@@ -637,7 +673,7 @@ if Pool.Submit('MyTask', @MyProcedure, 5) then
   WriteLn('Task submitted successfully');
 ```
 *)
-function TThreadPool.Submit(const TaskID: String; Method: procedure() of object; Priority: Integer = 0): Boolean;
+function TThreadPool.Submit(const TaskID: String; Method: procedure() of object; Priority: Integer = 0; AllowDuplicates: Boolean = False): Boolean;
 var
   NewTask: PThreadTask;
   ValidationError: String;
@@ -656,6 +692,13 @@ begin
   if Self.Terminating or not Self.Running or Self.ShuttingDown then
   begin
     Self.Log(EDebugLevel.INFO, Format('Cannot submit task "%s" - pool is shutting down', [TaskID]));
+    Exit;
+  end;
+
+  // Check for duplicates unless explicitly allowed
+  if not AllowDuplicates and Self.HasPendingTask(TaskID) then
+  begin
+    Self.Log(EDebugLevel.VERBOSE, Format('Task "%s" already pending - skipping duplicate', [TaskID]));
     Exit;
   end;
 
@@ -890,9 +933,17 @@ begin
          ((CurrentTime - Self.Tasks[i].LastRun) >= Self.Tasks[i].Interval) then
       begin
         TaskID := Format('%s-%d', [Self.Tasks[i].ID, CurrentTime]);
-        Self.Pool.Log(EDebugLevel.INFO, Format('Submitting recurring task "%s" (Interval: %dms)', [Self.Tasks[i].ID, Self.Tasks[i].Interval]));
-        Self.Pool.Submit(TaskID, @Self.Tasks[i].Method);
-        Self.Tasks[i].LastRun := CurrentTime;
+
+        // Check if previous execution is still running (optional overlap prevention)
+        if not Self.Pool.HasPendingTask(Self.Tasks[i].ID) then
+        begin
+          Self.Pool.Log(EDebugLevel.INFO, Format('Submitting recurring task "%s" (Interval: %dms)', [Self.Tasks[i].ID, Self.Tasks[i].Interval]));
+          // Use base task ID without timestamp for overlap detection
+          Self.Pool.Submit(Self.Tasks[i].ID, @Self.Tasks[i].Method);
+          Self.Tasks[i].LastRun := CurrentTime;
+        end
+        else
+          Self.Pool.Log(EDebugLevel.VERBOSE, Format('Skipping task "%s" - previous execution still running', [Self.Tasks[i].ID]));
       end;
 
     Sleep(Self.SleepIntervalMS);
@@ -1194,25 +1245,30 @@ end;
 (*
 ## TThreadManager.Submit
 ```pascal
-function TThreadManager.Submit(const TaskID: String; Method: procedure() of object; Priority: Integer = 0): Boolean;
+function TThreadManager.Submit(const TaskID: String; Method: procedure() of object; Priority: Integer = 0; AllowDuplicates: Boolean = False): Boolean;
 ```
-Submits a one-off task for asynchronous execution.
+Submits a one-off task for asynchronous execution. By default, prevents duplicate task IDs.
 
 ### Parameters
 - `TaskID`: A unique identifier for the task.
 - `Method`: The procedure to execute.
 - `Priority`: Task priority (higher values execute sooner). Default is 0.
+- `AllowDuplicates`: Whether to allow duplicate task IDs. Default is False.
 
 ### Returns
 - `Boolean`: `True` if task was successfully submitted, `False` otherwise.
 *)
-function TThreadManager.Submit(const TaskID: String; Method: procedure() of object; Priority: Integer = 0): Boolean;
+function TThreadManager.Submit(const TaskID: String; Method: procedure() of object; Priority: Integer = 0; AllowDuplicates: Boolean = False): Boolean;
 begin
   if not Self.IsSetup then
     Self.Init(0, Self.DebugLevel);
 
-  Result := Self.Pool.Submit(TaskID, @Method, Priority);
+  Result := Self.Pool.Submit(TaskID, @Method, Priority, AllowDuplicates);
 end;
+
+
+
+
 
 (*
 ## TThreadManager.Schedule
@@ -1323,7 +1379,7 @@ begin
     Exit(False);
 
   for i := 0 to High(TaskIDs) do
-    if not Self.Pool.Submit(TaskIDs[i], @Methods[i]) then
+    if not Self.Pool.Submit(TaskIDs[i], @Methods[i], 0, False) then
       Result := False;
 end;
 


### PR DESCRIPTION
### TEST (FYI will generate a few configs in `Simba2000/Configs/` that needs manual deletion)
```
Running: Config Threading Tests...
Testing that config saves don't freeze forms/UI...
  Testing config save doesn't block main thread...
  Testing multiple configs don't block main thread...
  Testing rapid saves don't block or cause file conflicts...
Performance: Actual save time was 15ms

Result: CONFIG THREADING TESTS PASSED 
```

```pascal
(*
# Config Threading Tests
Tests that config saves don't block the main thread and freeze forms.
*)

{$INCLUDE_ONCE WaspLib/utils.simba}

function MeasureSaveTime(var Config: TConfigJSON): Int64;
var
  StartTime: Int64;
begin
  StartTime := Time();
  Config.SaveConfig();
  Config.ThreadManager.Await(2000); // Wait for save to complete
  Result := Time() - StartTime;
end;

procedure SimulateFormWork(var ExecutionTime: Integer);
var
  i: Integer;
  start: Int64;
begin
  start := Time();
  // Simulate form/UI work that should not be blocked
  for i := 0 to 5000 do
    Sqrt(i * 3.14159);
  ExecutionTime := Time() - start;
end;

function TestNonBlockingSave(): Boolean;
var
  config: TConfigJSON;
  start: Int64;
  formTime: Integer;
begin
  Result := True;
  WriteLn('  Testing config save doesn''t block main thread...');
  
  config.Setup('test_nonblocking.json');
  config.Item['data'].AsString := 'This should save without blocking';
  config.Item['timestamp'].AsInt := Time();
  
  start := Time();
  config.SaveConfig();
  _Assert((Time() - start) < 50, 'Save submission should be instant (< 50ms)');
  
  // Form work should execute immediately without being blocked
  SimulateFormWork(formTime);
  _Assert(formTime < 100, 'Form work should complete quickly without blocking');
  
  Sleep(1000); // Wait for actual save to complete
  config.Free();
end;

function TestMultipleConfigsNonBlocking(): Boolean;
var
  configs: array[0..2] of TConfigJSON;
  i: Integer;
  start: Int64;
  formTime: Integer;
begin
  Result := True;
  WriteLn('  Testing multiple configs don''t block main thread...');
  
  // Setup multiple configs with different data
  for i := 0 to High(configs) do
  begin
    configs[i].Setup(Format('test_multi_%d.json', [i]));
    configs[i].Item['config_id'].AsInt := i;
    configs[i].Item['data'].AsString := Format('Config %d large data string that takes time to write', [i]);
  end;
  
  // Submit all saves - should be instant
  start := Time();
  for i := 0 to High(configs) do
    configs[i].SaveConfig();
  _Assert((Time() - start) < 50, 'Multiple saves should submit instantly');
  
  // Form should remain responsive
  SimulateFormWork(formTime);
  _Assert(formTime < 100, 'Form should remain responsive during saves');
  
  Sleep(1500); // Wait for saves to complete
  for i := 0 to High(configs) do
    configs[i].Free();
end;

function TestRapidSavesNonBlocking(): Boolean;
var
  config: TConfigJSON;
  i: Integer;
  start: Int64;
  formTime: Integer;
begin
  Result := True;
  WriteLn('  Testing rapid saves don''t block or cause file conflicts...');
  
  config.Setup('test_rapid.json');
  
  // Rapidly trigger saves (simulating user rapidly changing settings)
  start := Time();
  for i := 0 to 9 do
  begin
    config.Item['counter'].AsInt := i;
    config.Item['timestamp'].AsInt := Time();
    config.SaveConfig();
  end;
  _Assert((Time() - start) < 100, 'Rapid saves should submit quickly');
  
  // Form should still be responsive
  SimulateFormWork(formTime);
  _Assert(formTime < 100, 'Form should stay responsive during rapid saves');
  
  Sleep(1000);
  config.Free();
end;

function RunConfigTests(): Boolean;
var
  config: TConfigJSON;
  saveTime: Int64;
begin
  Result := True;
  WriteLn('Running: Config Threading Tests...');
  WriteLn('Testing that config saves don''t freeze forms/UI...');
  
  if not TestNonBlockingSave() then Result := False;
  if not TestMultipleConfigsNonBlocking() then Result := False;
  if not TestRapidSavesNonBlocking() then Result := False;
  
  // Quick performance check
  config.Setup('test_perf.json');
  config.Item['data'].AsString := 'Performance test data';
  saveTime := MeasureSaveTime(config);
  config.Free();
  
  WriteLn(Format('Performance: Actual save time was %dms', [saveTime]));
  WriteLn('');
end;

begin
  ClearSimbaOutput;

  if RunConfigTests() then
    WriteLn('Result: CONFIG THREADING TESTS PASSED')
  else
    WriteLn('Result: CONFIG THREADING TESTS FAILED');
end. 
```
